### PR TITLE
[#58] fix: comment reqeust에서 order group 정보 제거 및 대댓글 save API 추가

### DIFF
--- a/src/docs/asciidoc/comment.adoc
+++ b/src/docs/asciidoc/comment.adoc
@@ -63,6 +63,24 @@ include::{snippets}/comment/save/http-response.adoc[]
 === Response Fields
 include::{snippets}/comment/save/response-fields.adoc[]
 
+[[comment-reply]]
+== POST :: 대댓글 등록
+
+=== HTTP Request
+include::{snippets}/comment/reply/http-request.adoc[]
+
+=== Path Parameters
+include::{snippets}/comment/reply/path-parameters.adoc[]
+
+=== Request Fields
+include::{snippets}/comment/reply/request-fields.adoc[]
+
+=== HTTP Response
+include::{snippets}/comment/reply/http-response.adoc[]
+
+=== Response Fields
+include::{snippets}/comment/reply/response-fields.adoc[]
+
 [[comment-edit]]
 == PUT :: 댓글 수정
 

--- a/src/main/java/com/dnd5th3/dnd5th3backend/controller/CommentController.java
+++ b/src/main/java/com/dnd5th3/dnd5th3backend/controller/CommentController.java
@@ -56,4 +56,11 @@ public class CommentController {
         return ResponseEntity.ok(detailComment);
     }
 
+    @PostMapping("/{commentId}/reply")
+    public ResponseEntity<CommentResponseDto> saveReplyAPI(@PathVariable Long commentId, @RequestBody CommentRequestDto requestDto, @AuthenticationPrincipal Member member){
+        Comment comment = commentService.saveReplyComment(requestDto,commentId ,member);
+        CommentResponseDto commentResponseDto = modelMapper.map(comment, CommentResponseDto.class);
+        return ResponseEntity.status(HttpStatus.CREATED).body(commentResponseDto);
+    }
+
 }

--- a/src/main/java/com/dnd5th3/dnd5th3backend/controller/dto/comment/CommentListResponseDto.java
+++ b/src/main/java/com/dnd5th3/dnd5th3backend/controller/dto/comment/CommentListResponseDto.java
@@ -27,9 +27,7 @@ public class CommentListResponseDto {
         private long memberId;
         private String email;
         private String writerName;
-        private long groupNo;
         private int commentLayer;
-        private int commentOrder;
         private String content;
         private VoteType voteType;
         private int replyCount;

--- a/src/main/java/com/dnd5th3/dnd5th3backend/controller/dto/comment/CommentRequestDto.java
+++ b/src/main/java/com/dnd5th3/dnd5th3backend/controller/dto/comment/CommentRequestDto.java
@@ -8,8 +8,6 @@ import lombok.Getter;
 public class CommentRequestDto {
     private final Long postId;
     private final Long commentId;
-    private final Long groupNo;
     private final Integer commentLayer;
-    private final Integer commentOrder;
     private final String content;
 }

--- a/src/main/java/com/dnd5th3/dnd5th3backend/controller/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/dnd5th3/dnd5th3backend/controller/dto/comment/CommentResponseDto.java
@@ -12,9 +12,7 @@ import java.time.LocalDateTime;
 public class CommentResponseDto {
 
     private Long commentId;
-    private Long groupNo;
     private Integer commentLayer;
-    private Integer commentOrder;
     private String content;
     private Boolean isDeleted;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")

--- a/src/main/java/com/dnd5th3/dnd5th3backend/domain/comment/Comment.java
+++ b/src/main/java/com/dnd5th3/dnd5th3backend/domain/comment/Comment.java
@@ -42,16 +42,15 @@ public class Comment extends BaseTime {
     @OneToMany(fetch = FetchType.LAZY,mappedBy = "comment")
     private List<CommentEmoji> commentEmoji;
 
-    public static Comment create(CommentRequestDto requestDto,Member member,Posts posts) {
+    public static Comment create(CommentRequestDto requestDto,long groupNo,int commentLayer,int commentOrder,Member member,Posts posts) {
         Comment comment = Comment.builder()
-                .member(member)
-                .posts(posts)
-                .id(requestDto.getCommentId())
-                .groupNo(requestDto.getGroupNo())
-                .commentLayer(requestDto.getCommentLayer())
-                .commentOrder(requestDto.getCommentOrder())
+                .groupNo(groupNo)
+                .commentLayer(commentLayer)
+                .commentOrder(commentOrder)
                 .content(requestDto.getContent())
                 .isDeleted(Boolean.FALSE)
+                .member(member)
+                .posts(posts)
                 .build();
         posts.addComment(comment);
 

--- a/src/main/java/com/dnd5th3/dnd5th3backend/repository/comment/CommentRepository.java
+++ b/src/main/java/com/dnd5th3/dnd5th3backend/repository/comment/CommentRepository.java
@@ -15,4 +15,12 @@ public interface CommentRepository extends JpaRepository<Comment,Long>,CommentRe
             " WHERE c.posts.id = :postId AND c.groupNo = :groupNo" +
             " ORDER BY c.commentLayer, c.commentOrder")
     List<Comment> getCommentGroup(long postId,long groupNo);
+
+    @Query(" SELECT COALESCE(MAX(c.groupNo),0)+1 FROM Comment c" +
+           " WHERE c.posts.id = :postId AND c.commentLayer=:commentLayer")
+    long nextGroupNo(long postId,int commentLayer);
+
+    @Query(" SELECT COALESCE(MAX(c.commentOrder),0)+1 FROM Comment c" +
+           " WHERE c.id = :commentId AND c.groupNo = :groupNo AND c.commentLayer=:commentLayer")
+    int nextCommentOrder(long commentId,long groupNo,int commentLayer);
 }

--- a/src/main/java/com/dnd5th3/dnd5th3backend/service/CommentService.java
+++ b/src/main/java/com/dnd5th3/dnd5th3backend/service/CommentService.java
@@ -32,11 +32,23 @@ public class CommentService {
     private final VoteRepository voteRepository;
     private static final int LOWER_COMMENT = 1;
     private static final int PAGE_SIZE = 50;
+    private static final int TOP = 0;
 
     @Transactional
     public Comment saveComment(CommentRequestDto requestDto, Member member){
         Posts posts = postsRepository.findById(requestDto.getPostId()).orElseThrow();
-        Comment comment = Comment.create(requestDto, member, posts);
+        long nextGroupNo = commentRepository.nextGroupNo(requestDto.getPostId(), requestDto.getCommentLayer());
+        Comment comment = Comment.create(requestDto,nextGroupNo, requestDto.getCommentLayer(),TOP,member, posts);
+        return commentRepository.save(comment);
+    }
+
+    @Transactional
+    public Comment saveReplyComment(CommentRequestDto requestDto, long commentId ,Member member){
+        Comment topComment = commentRepository.findById(commentId).orElseThrow();
+        Posts posts = topComment.getPosts();
+        long groupNo = topComment.getGroupNo();
+        int nextCommentOrder = commentRepository.nextCommentOrder(commentId,groupNo,requestDto.getCommentLayer());
+        Comment comment = Comment.create(requestDto, groupNo, requestDto.getCommentLayer(), nextCommentOrder, member, posts);
         return commentRepository.save(comment);
     }
 

--- a/src/test/java/com/dnd5th3/dnd5th3backend/controller/CommentControllerTest.java
+++ b/src/test/java/com/dnd5th3/dnd5th3backend/controller/CommentControllerTest.java
@@ -98,9 +98,7 @@ class CommentControllerTest {
                                 fieldWithPath("commentList.[].memberId").description("회원 ID"),
                                 fieldWithPath("commentList.[].email").description("회원 이메일"),
                                 fieldWithPath("commentList.[].writerName").description("작성자 닉네임"),
-                                fieldWithPath("commentList.[].groupNo").description("댓글 그룹번호"),
                                 fieldWithPath("commentList.[].commentLayer").description("댓글 계층"),
-                                fieldWithPath("commentList.[].commentOrder").description("댓글 순서"),
                                 fieldWithPath("commentList.[].content").description("댓글 내용"),
                                 fieldWithPath("commentList.[].voteType").description("투표 상태"),
                                 fieldWithPath("commentList.[].createdDate").description("생성일자"),
@@ -138,16 +136,14 @@ class CommentControllerTest {
                         getDocumentRequest(),
                         getDocumentResponse(),
                         pathParameters(
-                                parameterWithName("commentId").description("글 ID")
+                                parameterWithName("commentId").description("댓글 ID")
                         ),
                         relaxedResponseFields(
                                 fieldWithPath("commentList.[].commentId").description("댓글 ID"),
                                 fieldWithPath("commentList.[].memberId").description("회원 ID"),
                                 fieldWithPath("commentList.[].email").description("회원 이메일"),
                                 fieldWithPath("commentList.[].writerName").description("작성자 닉네임"),
-                                fieldWithPath("commentList.[].groupNo").description("댓글 그룹번호"),
                                 fieldWithPath("commentList.[].commentLayer").description("댓글 계층"),
-                                fieldWithPath("commentList.[].commentOrder").description("댓글 순서"),
                                 fieldWithPath("commentList.[].content").description("댓글 내용"),
                                 fieldWithPath("commentList.[].voteType").description("투표 상태"),
                                 fieldWithPath("commentList.[].createdDate").description("생성일자"),
@@ -161,20 +157,17 @@ class CommentControllerTest {
     }
 
     @DisplayName("댓글 등록 API 테스트")
+    @Order(3)
     @Test
     void saveAPI() throws Exception {
 
         long postId = 1;
-        long groupNo = 8;
         int commentLayer = 0;
-        int commentOrder = 0;
         String content = "comment save test";
 
         Map<String,Object> request = new HashMap<>();
         request.put("postId",postId);
-        request.put("groupNo",groupNo);
         request.put("commentLayer",commentLayer);
-        request.put("commentOrder",commentOrder);
         request.put("content",content);
 
         ResultActions actions = mvc.perform(RestDocumentationRequestBuilders.post("/api/v1/comment")
@@ -192,16 +185,12 @@ class CommentControllerTest {
                         getDocumentResponse(),
                         relaxedRequestFields(
                                 fieldWithPath("postId").description("글 ID"),
-                                fieldWithPath("groupNo").description("댓글 그룹번호"),
                                 fieldWithPath("commentLayer").description("댓글 계층"),
-                                fieldWithPath("commentOrder").description("댓글 순서"),
                                 fieldWithPath("content").description("댓글 내용")
                         ),
                         responseFields(
                                 fieldWithPath("commentId").description("생성된 댓글 ID"),
-                                fieldWithPath("groupNo").description("댓글 그룹번호"),
                                 fieldWithPath("commentLayer").description("댓글 계층"),
-                                fieldWithPath("commentOrder").description("댓글 순서"),
                                 fieldWithPath("content").description("댓글 내용"),
                                 fieldWithPath("createdDate").description("생성일자"),
                                 fieldWithPath("updatedDate").description("수정일자"),
@@ -209,6 +198,52 @@ class CommentControllerTest {
                         )
                 ))
                 .andExpect(jsonPath("$.commentId").value(6L));
+
+    }
+
+    @DisplayName("대댓글 등록 API 테스트")
+    @Order(4)
+    @Test
+    void saveReplyAPI() throws Exception {
+
+        long commentId = 5;
+        int commentLayer = 1;
+        String content = "comment reply save test";
+
+        Map<String,Object> request = new HashMap<>();
+        request.put("commentLayer",commentLayer);
+        request.put("content",content);
+
+        ResultActions actions = mvc.perform(RestDocumentationRequestBuilders.post("/api/v1/comment/{commentId}/reply",commentId)
+                .principal(new UsernamePasswordAuthenticationToken(member,null))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding(Charsets.UTF_8.toString())
+                .content(objectMapper.writeValueAsString(request)));
+
+        actions
+                .andExpect(status().isCreated())
+                .andDo(print())
+                .andDo(document("comment/reply",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("commentId").description("댓글 ID")
+                        ),
+                        relaxedRequestFields(
+                                fieldWithPath("commentLayer").description("댓글 계층"),
+                                fieldWithPath("content").description("댓글 내용")
+                        ),
+                        responseFields(
+                                fieldWithPath("commentId").description("생성된 댓글 ID"),
+                                fieldWithPath("commentLayer").description("댓글 계층"),
+                                fieldWithPath("content").description("댓글 내용"),
+                                fieldWithPath("createdDate").description("생성일자"),
+                                fieldWithPath("updatedDate").description("수정일자"),
+                                fieldWithPath("isDeleted").description("삭제 여부")
+                        )
+                ))
+                .andExpect(jsonPath("$.content").value(content));
 
     }
 
@@ -242,9 +277,7 @@ class CommentControllerTest {
                         ),
                         relaxedResponseFields(
                                 fieldWithPath("commentId").description("댓글 ID"),
-                                fieldWithPath("groupNo").description("댓글 그룹번호"),
                                 fieldWithPath("commentLayer").description("댓글 계층"),
-                                fieldWithPath("commentOrder").description("댓글 순서"),
                                 fieldWithPath("content").description("수정된 댓글 내용"),
                                 fieldWithPath("createdDate").description("생성일자"),
                                 fieldWithPath("updatedDate").description("수정일자"),
@@ -281,9 +314,7 @@ class CommentControllerTest {
                         ),
                         relaxedResponseFields(
                                 fieldWithPath("commentId").description("삭제된 댓글 ID"),
-                                fieldWithPath("groupNo").description("댓글 그룹번호"),
                                 fieldWithPath("commentLayer").description("댓글 계층"),
-                                fieldWithPath("commentOrder").description("댓글 순서"),
                                 fieldWithPath("content").description("댓글 내용"),
                                 fieldWithPath("createdDate").description("생성일자"),
                                 fieldWithPath("updatedDate").description("수정일자"),

--- a/src/test/java/com/dnd5th3/dnd5th3backend/service/CommentServiceTest.java
+++ b/src/test/java/com/dnd5th3/dnd5th3backend/service/CommentServiceTest.java
@@ -33,6 +33,8 @@ class CommentServiceTest {
     @Autowired
     private ModelMapper modelMapper;
 
+    private static final int TOP = 0;
+
     @BeforeEach
     void setup(){
         long memberId = 1;
@@ -42,7 +44,7 @@ class CommentServiceTest {
     @DisplayName("댓글 등록 테스트")
     @Test
     void saveComment() {
-        CommentRequestDto commentRequestDto = new CommentRequestDto(1L, null, 1L, 0, 0, "comment test");
+        CommentRequestDto commentRequestDto = new CommentRequestDto(1L, null, TOP, "comment test");
         Comment comment = commentService.saveComment(commentRequestDto, member);
 
         CommentResponseDto commentResponseDto = modelMapper.map(comment, CommentResponseDto.class);
@@ -55,7 +57,7 @@ class CommentServiceTest {
     @Test
     void getComment() {
 
-        CommentRequestDto commentRequestDto = new CommentRequestDto(null, 1L, null, null, null, null);
+        CommentRequestDto commentRequestDto = new CommentRequestDto(null, 1L, null, null);
         Comment comment = commentService.deleteComment(commentRequestDto);
         assertEquals(commentRequestDto.getCommentId(),comment.getId(),"응답에 오류가 없는지 확인(삭제)");
     }
@@ -64,7 +66,7 @@ class CommentServiceTest {
     @Test
     void updateComment() {
 
-        CommentRequestDto commentRequestDto = new CommentRequestDto(null, 1L, null, null, null, "no.1 test content");
+        CommentRequestDto commentRequestDto = new CommentRequestDto(null, 1L, null,"no.1 test content");
         Comment comment = commentService.editComment(commentRequestDto);
         assertEquals(commentRequestDto.getCommentId(),comment.getId(),"응답에 오류가 없는지 확인(수정)");
     }
@@ -84,5 +86,14 @@ class CommentServiceTest {
         long expectedTotalCount = 3;
         CommentListResponseDto detailComment = commentService.getDetailComment(commentId);
         assertEquals(expectedTotalCount,detailComment.getCommentList().size(),"댓글 상세 개수 확인");
+    }
+
+    @DisplayName("대댓글 등록 테스트")
+    @Test
+    void saveReplyComment() {
+        long commentId = 3L;
+        CommentRequestDto commentRequestDto = new CommentRequestDto(null, null, 1,"no.3 comment reply content");
+        Comment comment = commentService.saveReplyComment(commentRequestDto, commentId, member);
+        assertEquals(commentRequestDto.getContent(),comment.getContent());
     }
 }

--- a/src/test/java/http/login.http
+++ b/src/test/java/http/login.http
@@ -21,8 +21,8 @@ PUT http://localhost:8080/api/v1/member/token
 Content-Type: application/json
 
 {
-  "email"        : "test@naver.com",
-  "refreshToken" : "1234"
+  "email"        : "test1@naver.com",
+  "refreshToken" : "eyJhbGciOiJIUzI1NiJ9.eyJjbGFpbSI6eyJyZWZyZXNoIjoiNWViM2RiYjgtMWQyMi00ZGFiLTk1NTYtNjEzOGI5NWZlNzFmIn0sImV4cCI6MTYzMDQ1NzY0NH0.2RkrjuX2Aucij4p89XO75xfGliCIRTTTn252fLp-4cY"
 }
 
 ###

--- a/src/test/resources/data-h2.sql
+++ b/src/test/resources/data-h2.sql
@@ -10,7 +10,7 @@ INSERT INTO vote (vote_id, created_date, updated_date, result, member_id, post_i
 INSERT INTO comment (comment_id, created_date, updated_date, comment_layer, comment_order, content, group_no, is_deleted, member_id, post_id) VALUES (1, '2021-08-06 12:41:15.025050', '2021-08-06 12:41:15.025050', 0, 0, 'no.1 test content', 1, false, 1, 1);
 INSERT INTO comment (comment_id, created_date, updated_date, comment_layer, comment_order, content, group_no, is_deleted, member_id, post_id) VALUES (2, '2021-08-06 13:41:15.025050', '2021-08-06 13:41:15.025050', 0, 0, 'no.2 test content', 2, false, 2, 1);
 INSERT INTO comment (comment_id, created_date, updated_date, comment_layer, comment_order, content, group_no, is_deleted, member_id, post_id) VALUES (3, '2021-08-06 15:41:15.025050', '2021-08-06 15:41:15.025050', 0, 0, 'no.3 test content', 3, false, 3, 1);
-INSERT INTO comment (comment_id, created_date, updated_date, comment_layer, comment_order, content, group_no, is_deleted, member_id, post_id) VALUES (4, '2021-08-06 16:41:15.025050', '2021-08-06 16:41:15.025050', 1, 0, 'no.3 reply test content', 3, false, 2, 1);
+INSERT INTO comment (comment_id, created_date, updated_date, comment_layer, comment_order, content, group_no, is_deleted, member_id, post_id) VALUES (4, '2021-08-06 16:41:15.025050', '2021-08-06 16:41:15.025050', 1, 1, 'no.3 reply test content', 3, false, 2, 1);
 INSERT INTO comment (comment_id, created_date, updated_date, comment_layer, comment_order, content, group_no, is_deleted, member_id, post_id) VALUES (5, '2021-08-06 17:41:15.025050', '2021-08-06 17:41:15.025050', 1, 1, 'no.3 reply test content', 3, false, 1, 1);
 
 INSERT INTO emoji (emoji_id, detail) VALUES (1, '1');


### PR DESCRIPTION
### 변경사항
- 댓글 대댓글 저장 API 분리
- 댓글 request 불필요 필드 제거(groupNo, commentOrder)